### PR TITLE
Requires celluloid before requiring sidekiq/fetch

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -1,4 +1,5 @@
 require 'sidekiq'
+require 'celluloid'
 require 'sidekiq/fetch'
 
 class Sidekiq::LimitFetch


### PR DESCRIPTION
I'm getting a "uninitialized constant Sidekiq::Actor::Celluloid (NameError)" when using sidekiq 2.12 and sidekiq-limit_fetch. From what I've seen, Celluloid is only loaded in Sidekiq in cli.rb#load_celluloid. I required it before requiring "sidekiq/fetch", and from the tests that I performed locally it worked ok.

(it seems like a similar error to https://github.com/mperham/sidekiq/issues/922 )
