### PR TITLE
Remove old Heroku reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ Add this line to your application's Gemfile:
 
 redis 2.6 or newer
 
-```
-heroku uses redis 2.4 by default
-to update version you need to contact their support:
-https://devcenter.heroku.com/articles/redistogo#redis-2-6
-```
-
 **Important note:** At this moment, `sidekiq-limit_fetch` is incompatible with Sidekiq Pro's `reliable_fetch`.
 
 https://github.com/mperham/sidekiq/issues/1508 — a sidekiq admin busy page is unreliable, so if you need to check how many workers are running a queue use a `#busy` method described below.


### PR DESCRIPTION
[Heroku uses 2.8 now](https://devcenter.heroku.com/articles/redistogo#redis-2-8). Good to keep the requirement's in there obviously, but there's no need to call out Heroku specifically anymore.
