### PR TITLE
Dynamic Queues

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -23,6 +23,11 @@ class Sidekiq::LimitFetch
 
   def initialize(options)
     Global::Monitor.start!
+
+    # Add Dynamic queues
+    queues = Sidekiq.redis { |conn| conn.smembers('queues') }
+    options[:queues] = options[:queues].concat(queues)
+
     @queues = Queues.new options.merge(namespace: determine_namespace)
   end
 


### PR DESCRIPTION
This code permit use of dynamic-queues

Example:

``` ruby
Sidekiq::Queue[queue_name].limit = 1

job_id = Sidekiq::Client.push({
  'class' => meta_worker.klass_name,
  'queue' => queue_name,
  'args'  => [args],
  'retry' => false
})
```
