### PR TITLE
change requirements to limitations in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this line to your application's Gemfile:
 
     gem 'sidekiq-limit_fetch'
 
-### Requirements
+### Limitations
 
 **Important note:** At this moment, `sidekiq-limit_fetch` is incompatible with
 - sidekiq pro's `reliable_fetch`


### PR DESCRIPTION
there aren't any requirements per say; the only things listed under requirements are actually limitations. this was confusing to my team, and others (see bottom of https://github.com/mperham/sidekiq/issues/200 )