### PR TITLE
Fix stuck queues bug on Redis restart (fix #75 and #72)

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -14,6 +14,8 @@ module Sidekiq::LimitFetch
   require_relative 'extensions/queue'
   require_relative 'extensions/manager'
 
+  TIMEOUT = Sidekiq::BasicFetch::TIMEOUT
+
   extend self
 
   def new(_)
@@ -33,13 +35,13 @@ module Sidekiq::LimitFetch
   def redis_retryable
     yield
   rescue Redis::BaseConnectionError
-    sleep 1
+    sleep TIMEOUT
     retry
   rescue Redis::CommandError => error
     # If Redis was restarted and is still loading its snapshot,
     # then we should treat this as a temporary connection error too.
     if error.message =~ /^LOADING/
-      sleep 1
+      sleep TIMEOUT
       retry
     else
       raise
@@ -47,8 +49,6 @@ module Sidekiq::LimitFetch
   end
 
   private
-
-  TIMEOUT = Sidekiq::BasicFetch::TIMEOUT
 
   def redis_brpop(queues)
     if queues.empty?

--- a/spec/sidekiq/limit_fetch_spec.rb
+++ b/spec/sidekiq/limit_fetch_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sidekiq::LimitFetch do
   let(:limits) {{ 'queue1' => 1, 'queue2' => 2 }}
 
   before do
-    subject::Queues.start options 
+    subject::Queues.start options
 
     Sidekiq.redis do |it|
       it.del 'queue:queue1'


### PR DESCRIPTION
I have debugged the issue we have on our production server: sometimes Redis is restarting for unknown reason. After that Sidekiq goes into quiet mode and stop processing jobs. The issue was already reported in #75 and #72. There was a try to fix that in #77, but the problem still remains.

The normal scenario for fetching new job is (with #77 applied):
1. aquire queues with `Queues.acquire`
2. fetch a job with `#redis_brpop`
3. retry fetching a job if there any connection errors (`Redis::BaseConnectionError`)
4. release queues with `Queues.release_except`

The first thing I noticed is that our Sidekiq instance is failing on step 3 not with `Redis::BaseConnectionError` but with `Redis::CommandError, "LOADING Redis is loading the dataset in memory"` error. It turns out that after restarting Redis spend some time restoring DB snapshot in memory, if snapshot size is very big that can be very long time (several seconds). So the failing scenario is:
1. aquire queues with `Queues.acquire`
* Redis is restarting
* Redis is loading DB snapshot in memory
2. fetch a job with `#redis_brpop`
* fetch is failing with `LOADING` error
* worker thread throws exception
3. (BUG!) queues never released back! 

I think of two ways of fixing that:
1. Treat `LOADING` error as a temporary connection error and sleep and retry (like in #77).
2. Don't allow to acquire queues twice without releasing them first. `Queues.acquire` should check if there are any previously acquired queues and return them.

I've implemented both.
