### PR TITLE
Updates that support Sidekiq 6.5+

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -28,13 +28,18 @@ module Sidekiq::LimitFetch
     UnitOfWork.new(queue, job) if job
   end
 
+  def config
+    # Post 6.5, Sidekiq.options is deprecated and replaced with passing Sidekiq directly
+    post_6_5? ? Sidekiq : Sidekiq.options
+  end
+
   # Backwards compatibility for sidekiq v6.1.0
   # @see https://github.com/mperham/sidekiq/pull/4602
   def bulk_requeue(*args)
     if Sidekiq::BasicFetch.respond_to?(:bulk_requeue) # < 6.1.0
       Sidekiq::BasicFetch.bulk_requeue(*args)
     else # 6.1.0+
-      Sidekiq::BasicFetch.new(Sidekiq.options).bulk_requeue(*args)
+      Sidekiq::BasicFetch.new(config).bulk_requeue(*args)
     end
   end
 
@@ -55,6 +60,10 @@ module Sidekiq::LimitFetch
   end
 
   private
+
+  def post_6_5?
+    @post_6_5 ||= Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
+  end
 
   def redis_brpop(queues)
     if queues.empty?

--- a/lib/sidekiq/limit_fetch/unit_of_work.rb
+++ b/lib/sidekiq/limit_fetch/unit_of_work.rb
@@ -1,7 +1,11 @@
 module Sidekiq
   class LimitFetch::UnitOfWork < BasicFetch::UnitOfWork
     def initialize(queue, job)
-      super
+      if post_6_5?
+        super(queue, job, Sidekiq)
+      else
+        super
+      end
       redis_retryable { Queue[queue_name].increase_busy }
     end
 
@@ -16,6 +20,10 @@ module Sidekiq
     end
 
     private
+
+    def post_6_5?
+      Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
+    end
 
     def redis_retryable(&block)
       Sidekiq::LimitFetch.redis_retryable(&block)


### PR DESCRIPTION
Some changes to Sidekiq internals require changes to how we pass
options to certain Sidekiq classes we inherit from. These changes
maintain backwards compatibility, but add some complexity to the
code.

There's some duplicated code with post_6_5? But I'm not entirely certain where would be better other than creating a utils class which seems overly complex for this gem. 