### PR TITLE
Fix deprecation of passing timeout as positional argument to brpop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- #137 - Fix deprecation of passing timeout as positional argument to brpop
+
 ## [4.3.0] - 2022-08-16
 
 - #135 - Some extra fixes for Sidekiq 6.5 (fixes #128, #130, #131) from [@BobbyMcWho](https://github.com/BobbyMcWho)

--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -70,7 +70,7 @@ module Sidekiq::LimitFetch
       sleep TIMEOUT  # there are no queues to handle, so lets sleep
       []             # and return nothing
     else
-      redis_retryable { Sidekiq.redis { |it| it.brpop *queues, TIMEOUT } }
+      redis_retryable { Sidekiq.redis { |it| it.brpop *queues, timeout: TIMEOUT } }
     end
   end
 end


### PR DESCRIPTION
The recent v4.8.0 of the redis gem deprecated passing `timeout` as a
positional argument in blocking commands like `brpop`:
https://github.com/redis/redis-rb/commit/08eea742485c054680ade3f9afd83f313c355595

v4.6 or greater of the redis gem is currently required and it already
included support for a `:timeout` hash option:
https://github.com/redis/redis-rb/blob/v4.6.0/lib/redis/distributed.rb#L465

Therefore we can switch to passing the timeout as a hash option.

Fixes #136.