### PR TITLE
Test coverage: add simplecov gem

### DIFF
--- a/sidekiq-limit_fetch.gemspec
+++ b/sidekiq-limit_fetch.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'sidekiq/limit_fetch'
 
 Sidekiq.logger = nil


### PR DESCRIPTION
I suggest to add [simplecov](https://github.com/simplecov-ruby/simplecov) gem to measure the test coverage