### PR TITLE
Sidekiq v7: fixes

### DIFF
--- a/lib/sidekiq/extensions/manager.rb
+++ b/lib/sidekiq/extensions/manager.rb
@@ -1,12 +1,11 @@
 class Sidekiq::Manager
   module InitLimitFetch
-    def initialize(options={})
+    def initialize(capsule_or_options)
       if Sidekiq::LimitFetch.post_7?
-        options.config[:fetch] = Sidekiq::LimitFetch
+        capsule_or_options.config[:fetch_class] = Sidekiq::LimitFetch
       else
-        options[:fetch] = Sidekiq::LimitFetch
+        capsule_or_options[:fetch]= Sidekiq::LimitFetch
       end
-      
       super
     end
 

--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -22,6 +22,10 @@ module Sidekiq::LimitFetch
     @post_7 ||= Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('7.0.0')
   end
 
+  def post_6_5?
+    @post_6_5 ||= Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
+  end
+
   RedisBaseConnectionError = post_7? ? RedisClient::ConnectionError : Redis::BaseConnectionError
   RedisCommandError = post_7? ? RedisClient::CommandError : Redis::CommandError
 
@@ -67,10 +71,6 @@ module Sidekiq::LimitFetch
   end
 
   private
-
-  def post_6_5?
-    @post_6_5 ||= Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('6.5.0')
-  end
 
   def redis_brpop(queues)
     if queues.empty?

--- a/lib/sidekiq/limit_fetch/queues.rb
+++ b/lib/sidekiq/limit_fetch/queues.rb
@@ -3,27 +3,25 @@ module Sidekiq::LimitFetch::Queues
 
   THREAD_KEY = :acquired_queues
 
-  def start(options)
-    if Sidekiq::LimitFetch.post_7?
-      options = options.config
-    end
+  def start(capsule_or_options)
+    config = Sidekiq::LimitFetch.post_7? ? capsule_or_options.config : capsule_or_options
 
-    @queues         = options[:queues]
-    @startup_queues = options[:queues].dup
+    @queues         = config[:queues]
+    @startup_queues = config[:queues].dup
 
-    if options[:dynamic].is_a? Hash
+    if config[:dynamic].is_a? Hash
       @dynamic         = true
-      @dynamic_exclude = options[:dynamic][:exclude] || []
+      @dynamic_exclude = config[:dynamic][:exclude] || []
     else
-      @dynamic = options[:dynamic]
+      @dynamic = config[:dynamic]
       @dynamic_exclude = []
     end
 
-    @limits         = options[:limits] || {}
-    @process_limits = options[:process_limits] || {}
-    @blocks         = options[:blocking] || []
+    @limits         = config[:limits] || {}
+    @process_limits = config[:process_limits] || {}
+    @blocks         = config[:blocking] || []
 
-    options[:strict] ? strict_order! : weighted_order!
+    config[:strict] ? strict_order! : weighted_order!
 
     apply_process_limit_to_queues
     apply_limit_to_queues

--- a/spec/sidekiq/extensions/manager_spec.rb
+++ b/spec/sidekiq/extensions/manager_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe Sidekiq::Manager do
+  let(:capsule_or_options) do
+    if Sidekiq::LimitFetch.post_7?
+      Sidekiq.default_configuration.default_capsule
+    elsif Sidekiq::LimitFetch.post_6_5?
+      Sidekiq
+    else
+      Sidekiq.options
+    end
+  end
+
+  it 'can be instantiated' do
+    expect(described_class).to be < Sidekiq::Manager::InitLimitFetch
+    manager = described_class.new(capsule_or_options)
+    expect(manager).to respond_to(:start)
+  end
+end

--- a/spec/sidekiq/limit_fetch/queues_spec.rb
+++ b/spec/sidekiq/limit_fetch/queues_spec.rb
@@ -13,7 +13,21 @@ RSpec.describe Sidekiq::LimitFetch::Queues do
       process_limits: process_limits }
   end
 
-  before { subject.start options }
+  let(:config) { Sidekiq::Config.new(options) }
+  let(:capsule) do
+    config.capsule("default") do |cap|
+      cap.concurrency = 1
+      cap.queues = config[:queues]
+    end
+  end
+
+  let(:capsule_or_options) do
+    Sidekiq::LimitFetch.post_7? ? capsule : options
+  end
+
+  before do
+    subject.start(capsule_or_options)
+  end
 
   def in_thread(&block)
     thr = Thread.new(&block)


### PR DESCRIPTION
 I think there are some missing changes to have the gem compatible with Sidekiq v7. The main one is the change on the customization of the "fetching class": it's now `fetch_class` and not `fetch` anymore (cf my GH comment).

I recommend to use the "Hide whitespace option" when reviewing, because there is some indentation change in `spec/sidekiq/limit_fetch/global/monitor_spec.rb` file.