### PR TITLE
fix queues value

### DIFF
--- a/lib/sidekiq/limit_fetch.rb
+++ b/lib/sidekiq/limit_fetch.rb
@@ -53,7 +53,7 @@ module Sidekiq
       if Sidekiq::BasicFetch.respond_to?(:bulk_requeue) # < 6.1.0
         Sidekiq::BasicFetch.bulk_requeue(*args)
       else # 6.1.0+
-        Sidekiq::BasicFetch.new(config).bulk_requeue(*args)
+        Sidekiq::BasicFetch.new(post_7? ? Sidekiq.default_configuration.default_capsule : config).bulk_requeue(*args)
       end
     end
 

--- a/lib/sidekiq/limit_fetch/queues.rb
+++ b/lib/sidekiq/limit_fetch/queues.rb
@@ -14,8 +14,14 @@ module Sidekiq
       def start(capsule_or_options)
         config = Sidekiq::LimitFetch.post_7? ? capsule_or_options.config : capsule_or_options
 
-        @queues         = config[:queues]
-        @startup_queues = config[:queues].dup
+        @queues = config[:queues].map do |queue|
+          if queue.is_a? Array
+            queue.first
+          else
+            queue
+          end
+        end.uniq
+        @startup_queues = @queues.dup
 
         if config[:dynamic].is_a? Hash
           @dynamic         = true


### PR DESCRIPTION
Fixes #153. 

The `undefined method to_sym` is occurred when `queues` have array in a `sidekiq.yml`. If `queues` have queue name and weighting, `config[:queues]` also get queue name and weighting. I think that `config[:queues]` have only queue name. Therefore , I tried to get only the queue name if `config[:queues]` have weighting besides queue name.