### PR TITLE
Honor existing deployed limits

### DIFF
--- a/lib/sidekiq/limit_fetch/queues.rb
+++ b/lib/sidekiq/limit_fetch/queues.rb
@@ -142,6 +142,8 @@ module Sidekiq
 
       def apply_process_limit_to_queue(queue_name)
         queue = Sidekiq::Queue[queue_name]
+        return unless queue.process_limit.nil? # honor existing deployed limits
+
         queue.process_limit = @process_limits[queue_name.to_s] || @process_limits[queue_name.to_sym]
       end
 
@@ -155,6 +157,7 @@ module Sidekiq
         queue = Sidekiq::Queue[queue_name]
 
         return if queue.limit_changed?
+        return unless queue.limit.nil? # honor existing deployed limits
 
         queue.limit = @limits[queue_name.to_s] || @limits[queue_name.to_sym]
       end


### PR DESCRIPTION
In a cluster with auto-scaling sidekiq servers, a new server entering the pool runs Queues.start, which looks at the config file and sets the limit and process_limit values accordingly.  However, if at runtime these values have been changed dynamically for any reason, this overwrites the values with what is in the config file, or removes the limits if there are none in the config file.  This is unexpected behavior.

Instead, at startup, honor the values found in redis if any are present.  Only set the values if none are present in redis.