### PR TITLE
Fix rubocop failures and github checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,8 @@ Naming/VariableNumber:
 Naming/FileName:
   Exclude:
     - lib/sidekiq-limit_fetch.rb
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+  Exclude:
+    - 'demo/*'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@
 
 source 'https://rubygems.org'
 gemspec
-
-gem 'sidekiq'

--- a/gemfiles/sidekiq_6.0.gemfile.lock
+++ b/gemfiles/sidekiq_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,15 +11,27 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -33,14 +45,36 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (6.0.7)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -48,8 +82,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 6.0.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_6.1.gemfile.lock
+++ b/gemfiles/sidekiq_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,13 +11,25 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,13 +43,35 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (6.1.3)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -45,8 +79,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 6.1.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_6.2.gemfile.lock
+++ b/gemfiles/sidekiq_6.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,13 +11,25 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,13 +43,35 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -45,8 +79,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 6.2.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_6.3.gemfile.lock
+++ b/gemfiles/sidekiq_6.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,13 +11,25 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,13 +43,35 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (6.3.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -45,8 +79,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 6.3.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_6.4.gemfile.lock
+++ b/gemfiles/sidekiq_6.4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,13 +11,25 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,13 +43,35 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (6.4.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -45,8 +79,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 6.4.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_6.5.gemfile.lock
+++ b/gemfiles/sidekiq_6.5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,13 +11,25 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -31,13 +43,35 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (6.5.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -45,8 +79,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 6.5.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_7.0.gemfile.lock
+++ b/gemfiles/sidekiq_7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -11,10 +11,20 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     concurrent-ruby (1.1.10)
     connection_pool (2.3.0)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (3.0.2)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (5.0.5)
       redis-client (>= 0.9.0)
@@ -22,6 +32,8 @@ GEM
       connection_pool
     redis-namespace (1.10.0)
       redis (>= 4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -35,14 +47,36 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     sidekiq (7.0.2)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.11.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 
@@ -51,8 +85,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq (~> 7.0.0)
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5

--- a/gemfiles/sidekiq_master.gemfile.lock
+++ b/gemfiles/sidekiq_master.gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: ..
   specs:
-    sidekiq-limit_fetch (4.4.0)
+    sidekiq-limit_fetch (4.4.1)
       sidekiq (>= 6)
 
 GEM
@@ -20,13 +20,25 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
+    ast (2.4.2)
     connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    docile (1.4.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rack (2.2.3.1)
+    rainbow (3.1.1)
     rake (13.0.6)
     redis (4.6.0)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -40,9 +52,31 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.60.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.1)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -50,8 +84,10 @@ DEPENDENCIES
   rake
   redis-namespace (~> 1.5, >= 1.5.2)
   rspec
+  rubocop
   sidekiq!
   sidekiq-limit_fetch!
+  simplecov
 
 BUNDLED WITH
    2.3.5


### PR DESCRIPTION
Rubocop wants the development dependencies to be specified in the Gemfile. Ours are in gemspec. Override the rubocop rule. Ignore the demo/ directory that just specifies gem sidekiq in Gemfile.  Re-establish the lockfiles for CI as a result.

GitHub has a new version of the checkout action needed for newer nodejs.