### PR TITLE
Emphasize the limitations in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Then `bundle install`.
 
 ### Limitations
 
-**Important note:** At this moment, `sidekiq-limit_fetch` is incompatible with
-- sidekiq pro's `reliable_fetch`
-- `sidekiq-rate-limiter`
-- any other plugin that rewrites fetch strategy of sidekiq.
+> [!WARNING]
+> At this moment, `sidekiq-limit_fetch` is incompatible with
+> sidekiq pro's [super_fetch](https://github.com/sidekiq/sidekiq/wiki/Reliability#using-super_fetch),
+> [sidekiq-rate-limiter](https://github.com/enova/sidekiq-rate-limiter),
+> and any other plugin that rewrites fetch strategy of sidekiq.
 
 ### Usage
 


### PR DESCRIPTION
`reliable_fetch` in Sidekiq Pro is no longer supported. Now that `super_fetch` is being used, I updated the README accordingly.

Several of my clients were using both Sidekiq Pro's `super_fetch` and `sidekiq-limit_fetch` together. To help prevent this from happening again, I made the limitations more visible in the README.