### PR TITLE
Fixes bug where queue weights are not honored anymore

### DIFF
--- a/lib/sidekiq/limit_fetch/queues.rb
+++ b/lib/sidekiq/limit_fetch/queues.rb
@@ -12,16 +12,20 @@ module Sidekiq
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/PerceivedComplexity
       def start(capsule_or_options)
-        config = Sidekiq::LimitFetch.post_7? ? capsule_or_options.config : capsule_or_options
-
-        @queues = config[:queues].map do |queue|
-          if queue.is_a? Array
-            queue.first
-          else
-            queue
-          end
-        end.uniq
-        @startup_queues = @queues.dup
+        if Sidekiq::LimitFetch.post_7?
+          config = capsule_or_options.config
+          # Capsule#queues= has already expanded [name, weight] pairs into
+          # weight-many copies of each name. Keep the duplicates — they are what
+          # weighted_order!'s shuffle.uniq derives the weighted ordering from.
+          @queues = capsule_or_options.queues.dup
+          strict  = capsule_or_options.mode == :strict
+        else
+          config = capsule_or_options
+          # Sidekiq::CLI#parse_queue has already expanded weights the same way.
+          @queues = config[:queues].dup
+          strict  = !!config[:strict]
+        end
+        @startup_queues = @queues.uniq
 
         if config[:dynamic].is_a? Hash
           @dynamic         = true
@@ -35,7 +39,7 @@ module Sidekiq
         @process_limits = config[:process_limits] || {}
         @blocks         = config[:blocking] || []
 
-        config[:strict] ? strict_order! : weighted_order!
+        strict ? strict_order! : weighted_order!
 
         apply_process_limit_to_queues
         apply_limit_to_queues

--- a/spec/sidekiq/limit_fetch/queues_spec.rb
+++ b/spec/sidekiq/limit_fetch/queues_spec.rb
@@ -124,4 +124,13 @@ RSpec.describe Sidekiq::LimitFetch::Queues do
   it 'with strict flag should retrieve strictly ordered queues' do
     expect(subject.ordered_queues).to eq %w[queue1 queue2]
   end
+
+  context 'queue weights' do
+    it 'keeps the weight-expanded duplicates so weighted ordering still works' do
+      Sidekiq::LimitFetch::Queues.start(queues: %w(a a a b), strict: false)
+
+      expect(Sidekiq::LimitFetch::Queues.instance_variable_get(:@queues).tally)
+        .to eq('a' => 3, 'b' => 1)
+    end
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/deanpcmad/sidekiq-limit_fetch/issues/165

Since 4.4.1, `Queues#start` calls `.uniq` on the queue list at boot. Sidekiq encodes a queue weight of N by repeating the queue name N times (`Sidekiq::CLI#parse_queue` on 6.x, `Capsule#queues=` on 7.x), and `weighted_order!`'s `@queues.shuffle.uniq` derives the weighted fetch order from those duplicates — so deduping at boot collapses weighted mode into a uniform shuffle. Measured with a 20:1 weighted pair: the heavy queue is polled first ~95% of cycles on 4.4.0 and ~50% on 4.4.1, on both sidekiq 6.5.12 and 7.3.9 (repro script in the issue).

This PR makes `start` take the already-expanded list from where each Sidekiq version keeps it, without deduping:

- **Sidekiq 6.x**: `config[:queues]` (expanded by the CLI) — as 4.3.2/4.4.0 did.
- **Sidekiq 7.x**: `capsule.queues` — `capsule.config[:queues]` holds the raw `[[name, weight], …]` YAML shape (`Config#merge!` is a plain hash delegate), so the previous `map { queue.first }` dropped the weights there too. Strictness now comes from `capsule.mode == :strict`, since the Sidekiq 7 CLI never sets `config[:strict]` — this also fixes strict (unweighted) configs wrongly getting `weighted_order!` on 7.

The per-fetch dedup that BRPOP needs already happens downstream (`shuffle.uniq` in `weighted_order!`, `@queues.uniq!` in `strict_order!`), where it is lossless because the weight information has already been converted into list position.